### PR TITLE
Add symmetry module and density attributes

### DIFF
--- a/src/totypes/__init__.py
+++ b/src/totypes/__init__.py
@@ -3,5 +3,6 @@
 __version__ = "0.0.0"
 __author__ = "Martin Schubert <mfschubert@gmail.com>"
 
-from totypes import types as types
 from totypes import json_utils as json_utils
+from totypes import symmetry as symmetry
+from totypes import types as types

--- a/src/totypes/symmetry.py
+++ b/src/totypes/symmetry.py
@@ -1,0 +1,79 @@
+"""Defines symmetries for arrays."""
+
+from typing import Any, Tuple
+
+import jax.numpy as jnp
+from jax import tree_util
+
+REFLECTION_NE_SW = "reflection_ne_sw"
+REFLECTION_NW_SE = "reflection_nw_se"
+REFLECTION_N_S = "reflection_n_s"
+REFLECTION_E_W = "reflection_e_w"
+ROTATION_180 = "rotation_180"
+ROTATION_90 = "rotation_90"
+
+
+def symmetrize(
+    custom_type: Any,
+    symmetries: Tuple[str, ...],
+) -> Any:
+    """Apply specified symmetries to a custom type with a single leaf node."""
+    if not isinstance(symmetries, tuple):
+        raise ValueError(
+            f"`symmetries` must be a tuple of `str`, but got {symmetries}."
+        )
+    (array,), treedef = tree_util.tree_flatten(custom_type)
+    for symmetry in symmetries:
+        if symmetry not in SYMMETRY_FNS:
+            raise ValueError(f"Unrecognized symmetry: {symmetry}")
+        array = SYMMETRY_FNS[symmetry](array)
+    return tree_util.tree_unflatten(treedef, (array,))
+
+
+def _reflection_ne_sw(array: jnp.ndarray) -> jnp.ndarray:
+    """Transform `array` to have reflection symmetry about the ne-sw axis."""
+    assert array.shape[-2] == array.shape[-1]
+    return (array + array[..., ::-1, ::-1].T) / 2
+
+
+def _reflection_nw_se(array: jnp.ndarray) -> jnp.ndarray:
+    """Transform `array` to have reflection symmetry about the nw-se axis."""
+    assert array.shape[-2] == array.shape[-1]
+    return (array + array.T) / 2
+
+
+def _reflection_n_s(array: jnp.ndarray) -> jnp.ndarray:
+    """Transform `array` to have reflection symmetry about the n-s axis."""
+    return (array + array[..., ::-1, :]) / 2
+
+
+def _reflection_e_w(array: jnp.ndarray) -> jnp.ndarray:
+    """Transform `array` to have reflection symmetry about the e-w axis."""
+    return (array + array[..., ::-1]) / 2
+
+
+def _rotation_180(array: jnp.ndarray) -> jnp.ndarray:
+    """Transform `array` to have 180-degree rotational symmetry."""
+    return (array + jnp.rot90(array, 2)) / 2
+
+
+def _rotation_90(array: jnp.ndarray) -> jnp.ndarray:
+    """Transform `array` to have 90-degree rotational symmetry."""
+    assert array.shape[-2] == array.shape[-1]
+    return (array + jnp.rot90(array, 1) + jnp.rot90(array, 2) + jnp.rot90(array, 3)) / 4
+
+
+SYMMETRY_FNS = {
+    REFLECTION_NE_SW: _reflection_ne_sw,
+    REFLECTION_NW_SE: _reflection_nw_se,
+    REFLECTION_N_S: _reflection_n_s,
+    REFLECTION_E_W: _reflection_e_w,
+    ROTATION_180: _rotation_180,
+    ROTATION_90: _rotation_90,
+}
+
+SYMMETRIES_REQUIRING_SQUARE_ARRAYS = (
+    REFLECTION_NE_SW,
+    REFLECTION_NW_SE,
+    ROTATION_90,
+)

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -1,14 +1,13 @@
 """Defines tests for the `totypes.json_utils` module."""
 
+import dataclasses
+import unittest
 from typing import NamedTuple
 
-import unittest
-
-import dataclasses
 import jax
 import jax.numpy as jnp
 import numpy as onp
-import parameterized
+from parameterized import parameterized
 
 from totypes import json_utils, types
 
@@ -51,9 +50,7 @@ DENSITY_2D_ARRAYS = [
 
 
 class SerializeDeserializeTest(unittest.TestCase):
-    @parameterized.parameterized.expand(
-        [[a] for a in ARRAYS + BOUNDED_ARRAYS + DENSITY_2D_ARRAYS]
-    )
+    @parameterized.expand([[a] for a in ARRAYS + BOUNDED_ARRAYS + DENSITY_2D_ARRAYS])
     def test_serialize_deserialize_arrays(self, array):
         (expected_leaf,), expected_pytreedef = jax.tree_util.tree_flatten(array)
 

--- a/tests/test_symmetry.py
+++ b/tests/test_symmetry.py
@@ -1,0 +1,146 @@
+"""Defines tests for the `totypes.symmetry` module."""
+
+import unittest
+
+import jax.numpy as jnp
+import numpy as onp
+from parameterized import parameterized
+
+from totypes import symmetry, types
+
+TEST_ARRAY = jnp.asarray(
+    [
+        [0, 4, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+        [0, 0, 0, 0, 0],
+    ]
+)
+
+TEST_BOUNDED_ARRAY = types.BoundedArray(
+    array=TEST_ARRAY,
+    lower_bound=None,
+    upper_bound=None,
+)
+
+TEST_DENSITY_2D = types.Density2DArray(
+    array=TEST_ARRAY,
+)
+
+
+def _assert_array_equal(x, expected_array):
+    if isinstance(x, jnp.ndarray):
+        onp.testing.assert_array_equal(x, expected_array)
+    else:
+        onp.testing.assert_array_equal(x.array, expected_array)
+
+
+class SymmetryFunctionTest(unittest.TestCase):
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_rotation_180(self, obj):
+        result = symmetry.symmetrize(obj, (symmetry.ROTATION_180,))
+        expected = jnp.asarray(
+            [
+                [0, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 2, 0],
+            ]
+        )
+        _assert_array_equal(result, expected)
+
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_rotation_90(self, obj):
+        result = symmetry.symmetrize(obj, (symmetry.ROTATION_90,))
+        expected = jnp.asarray(
+            [
+                [0, 1, 0, 0, 0],
+                [0, 0, 0, 0, 1],
+                [0, 0, 0, 0, 0],
+                [1, 0, 0, 0, 0],
+                [0, 0, 0, 1, 0],
+            ]
+        )
+        _assert_array_equal(result, expected)
+
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_reflection_n_s(self, obj):
+        result = symmetry.symmetrize(obj, (symmetry.REFLECTION_N_S,))
+        expected = jnp.asarray(
+            [
+                [0, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 2, 0, 0, 0],
+            ]
+        )
+        _assert_array_equal(result, expected)
+
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_reflection_e_w(self, obj):
+        result = symmetry.symmetrize(obj, (symmetry.REFLECTION_E_W,))
+        expected = jnp.asarray(
+            [
+                [0, 2, 0, 2, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ]
+        )
+        _assert_array_equal(result, expected)
+
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_reflection_ne_sw(self, obj):
+        result = symmetry.symmetrize(obj, (symmetry.REFLECTION_NE_SW,))
+        expected = jnp.asarray(
+            [
+                [0, 2, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 2],
+                [0, 0, 0, 0, 0],
+            ]
+        )
+        _assert_array_equal(result, expected)
+
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_reflection_nw_se(self, obj):
+        result = symmetry.symmetrize(obj, (symmetry.REFLECTION_NW_SE,))
+        expected = jnp.asarray(
+            [
+                [0, 2, 0, 0, 0],
+                [2, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+                [0, 0, 0, 0, 0],
+            ]
+        )
+        _assert_array_equal(result, expected)
+
+    @parameterized.expand([[TEST_ARRAY], [TEST_BOUNDED_ARRAY], [TEST_DENSITY_2D]])
+    def test_multiple_symmetry(self, obj):
+        result = symmetry.symmetrize(
+            obj,
+            (
+                symmetry.ROTATION_90,
+                symmetry.ROTATION_180,
+                symmetry.REFLECTION_E_W,
+                symmetry.REFLECTION_N_S,
+                symmetry.REFLECTION_NE_SW,
+                symmetry.REFLECTION_NW_SE,
+            ),
+        )
+        expected = jnp.asarray(
+            [
+                [0.0, 0.5, 0.0, 0.5, 0.0],
+                [0.5, 0.0, 0.0, 0.0, 0.5],
+                [0.0, 0.0, 0.0, 0.0, 0.0],
+                [0.5, 0.0, 0.0, 0.0, 0.5],
+                [0.0, 0.5, 0.0, 0.5, 0.0],
+            ]
+        )
+        _assert_array_equal(result, expected)


### PR DESCRIPTION
- Add a new symmetry module, with functions to apply symmetries to arrays and custom types. Reflection and rotation symmetries are supported.
- Add "periodic" property to the `Density2DArray` which specifies whether periodic or non-periodic boundary conditions are desired.
- Add `symmetries` attribute to the `Density2DArray` which lists the symmetries, and a `symmetrize_density` function which applies the required symmetries.