### PR TITLE
Cast sequence to tuple

### DIFF
--- a/src/totypes/types.py
+++ b/src/totypes/types.py
@@ -153,6 +153,9 @@ class Density2DArray:
     symmetries: Sequence[str] = ()
 
     def __post_init__(self) -> None:
+        self.periodic = tuple(self.periodic)
+        self.symmetries = tuple(self.symmetries)
+
         # Attributes may be strings if they are serialized, or jax tracers
         # e.g. when computing gradients. Avoid validation in these cases.
         if not isinstance(self.array, (jnp.ndarray, onp.ndarray)):

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -36,8 +36,8 @@ DENSITY_2D_ARRAYS = [
         fixed_void=jnp.ones((3, 3), dtype=bool),
         minimum_width=2,
         minimum_spacing=3,
-        periodic=[True, False],
-        symmetries=[symmetry.ROTATION_180, symmetry.REFLECTION_N_S],
+        periodic=(True, False),
+        symmetries=(symmetry.ROTATION_180, symmetry.REFLECTION_N_S),
     ),
     types.Density2DArray(
         array=onp.ones((3, 3)),
@@ -47,8 +47,8 @@ DENSITY_2D_ARRAYS = [
         fixed_void=onp.ones((3, 3), dtype=bool),
         minimum_width=2,
         minimum_spacing=3,
-        periodic=[True, True],
-        symmetries=[],
+        periodic=(True, True),
+        symmetries=(),
     ),
 ]
 


### PR DESCRIPTION
Here we cast the `periodic` and `symmetries` attributes to be tuples. This is intended to resolve pytree inconsistency when serializing/deserializing pytrees including densities.