### PR TITLE
Add ability to register custom types

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.1.0"
+current_version = "v0.2.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # totypes - Custom types for topology optimization
-`v0.1.0`
+`v0.2.0`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "totypes"
-version = "v0.1.0"
+version = "v0.2.0"
 description = "Custom datatypes useful in a topology optimization context"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/totypes/__init__.py
+++ b/src/totypes/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.1.0"
+__version__ = "v0.2.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 __all__ = ["json_utils", "symmetry", "types"]

--- a/src/totypes/json_utils.py
+++ b/src/totypes/json_utils.py
@@ -43,7 +43,7 @@ def register_custom_type(custom_type: Any) -> None:
 
 def _prefix_for_custom_type(custom_type: Any) -> str:
     """Return the prefix for a custom type."""
-    type_str = str(custom_type).split(".")[-1]
+    type_str = str(custom_type)
     type_hash = hash(type_str)
     type_hash_str = f"{'p' if type_hash > 0 else 'n'}{abs(type_hash)}"
     return f"\x93TYPES.{type_hash_str}.{type_str}."

--- a/src/totypes/json_utils.py
+++ b/src/totypes/json_utils.py
@@ -7,35 +7,108 @@ import dataclasses
 import functools
 import io
 import json
-from typing import Any, Dict, Tuple, Union
+from typing import Any, Dict, Sequence, Tuple, Union
 
 import jax.numpy as jnp
 import numpy as onp
 from jax import tree_util
 
-from totypes import types
-
 PyTree = Any
 
-NUMPY_ASCII_FORMAT = "latin-1"
-PREFIX_NUMPY = "\x93NUMPY"
+_NUMPY_ASCII_FORMAT = "latin-1"
+_PREFIX_NUMPY = "\x93NUMPY"
+_CUSTOM_TYPE_REGISTRY: Dict[str, Any] = {}
 
-CUSTOM_TYPES_AND_PREFIXES = (
-    (types.BoundedArray, "\x93TYPES.BOUNDED_ARRAY"),
-    (types.Density2DArray, "\x93TYPES.DENSITY_2D_ARRAY"),
-)
+
+def register_custom_type(custom_type: Any) -> None:
+    """Register a custom type so that it can be serialized and deserialized.
+
+    To support serialization and deserialization, custom types must be either
+    dataclasses or namedtuples and their attributes must be numpy or jax arrays
+    or have types that are json-serializable by default (e.g. strings).
+
+    Args:
+        custom_type: The custom type to be serialized.
+    """
+    if not (dataclasses.is_dataclass(custom_type) or _is_namedtuple(custom_type)):
+        raise ValueError(
+            f"Only dataclasses and namedtuples are supported, but got {custom_type}."
+        )
+    if custom_type in _CUSTOM_TYPE_REGISTRY.values():
+        raise ValueError(f"Duplicate custom type registration for {custom_type}.")
+    prefix = _prefix_for_custom_type(custom_type)
+    _validate_prefix(prefix, list(_CUSTOM_TYPE_REGISTRY.keys()))
+    _CUSTOM_TYPE_REGISTRY[prefix] = custom_type
+
+
+def _prefix_for_custom_type(custom_type: Any) -> str:
+    """Return the prefix for a custom type."""
+    type_str = str(custom_type).split(".")[-1]
+    type_hash = hash(type_str)
+    type_hash_str = f"{'p' if type_hash > 0 else 'n'}{abs(type_hash)}"
+    return f"\x93TYPES.{type_hash_str}.{type_str}."
+
+
+def _validate_prefix(test_prefix: str, existing_prefixes: Sequence[str]) -> None:
+    """Validate that `test_prefix` does not conflict with `existing_prefixes."""
+    for p in existing_prefixes:
+        if (
+            p.startswith(_PREFIX_NUMPY)
+            or p.startswith(test_prefix)
+            or test_prefix.startswith(p)
+        ):
+            raise ValueError(
+                f"Prefix {test_prefix} confilcts with existing {existing_prefixes}."
+            )
+
+
+def _validate_prefixes(prefixes: Sequence[str]) -> None:
+    """Validates that prefixes are not in conflict."""
+    for i, p in enumerate(prefixes):
+        _validate_prefix(p, prefixes[i + 1 :])
+
+
+def _is_namedtuple(custom_type: Any) -> bool:
+    """Return `True` if `custom_type` is a `namedtuple`."""
+    return hasattr(custom_type, "_asdict")
+
+
+# -----------------------------------------------------------------------------
+# Serialization functions.
+# -----------------------------------------------------------------------------
 
 
 def json_from_pytree(
     pytree: PyTree,
     extra_custom_types_and_prefixes: Tuple[Tuple[Any, str], ...] = (),
 ) -> str:
-    """Serializes a pytree containing arrays into a json string."""
+    """Serializes a pytree containing arrays into a json string.
+
+    Extra custom types and prefixes can be manually specified so as to allow user-
+    defined objects to be serialized, so long as they are dataclasses or namedtuples,
+    and have leaves that are jax or numpy arrays, or are types that are natively
+    json-serializable (e.g. strings).
+
+    In addition to manually specifying custom types, custom types can be registered
+    using the `register_custom_type` function.
+
+    Args:
+        pytree: The pytree to be serialized.
+        extra_custom_types_and_prefixes: The additional custom types and prefixes.
+            Note that any manually-specified custom types may override registered
+            custom types.
+
+    Returns:
+        The serialized pytree.
+    """
     custom_types_and_prefixes = tuple(
-        set(CUSTOM_TYPES_AND_PREFIXES + extra_custom_types_and_prefixes)
+        set(
+            tuple([(t, p) for p, t in _CUSTOM_TYPE_REGISTRY.items()])
+            + extra_custom_types_and_prefixes
+        )
     )
-    _validate_prefixes(custom_types_and_prefixes)
-    custom_types, _ = zip(*custom_types_and_prefixes)
+    custom_types, prefixes = zip(*custom_types_and_prefixes)
+    _validate_prefixes(prefixes)
     pytree_with_serialized = tree_util.tree_map(
         f=functools.partial(
             _maybe_serialize,
@@ -79,18 +152,40 @@ def _serialize_array(obj: Union[onp.ndarray, jnp.ndarray]) -> str:
     obj = onp.asarray(obj)
     memfile = io.BytesIO()
     onp.save(memfile, obj)
-    return memfile.getvalue().decode(NUMPY_ASCII_FORMAT)
+    return memfile.getvalue().decode(_NUMPY_ASCII_FORMAT)
 
 
 def pytree_from_json(
     serialized: str,
     extra_custom_types_and_prefixes: Tuple[Tuple[Any, str], ...] = (),
 ) -> PyTree:
-    """Deserializes a json string into a pytree of arrays."""
+    """Deserializes a json string into a pytree of arrays.
+
+    Extra custom types and prefixes can be manually specified so as to allow user-
+    defined objects to be serialized, so long as they are dataclasses or namedtuples,
+    and have leaves that are jax or numpy arrays, or are types that are natively
+    json-serializable (e.g. strings).
+
+    In addition to manually specifying custom types, custom types can be registered
+    using the `register_custom_type` function.
+
+    Args:
+        serialized: The serialized pytree.
+        extra_custom_types_and_prefixes: The additional custom types and prefixes.
+            Note that any manually-specified custom types may override registered
+            custom types.
+
+    Returns:
+        The deserialized pytree.
+    """
     custom_types_and_prefixes = tuple(
-        set(CUSTOM_TYPES_AND_PREFIXES + extra_custom_types_and_prefixes)
+        set(
+            tuple([(t, p) for p, t in _CUSTOM_TYPE_REGISTRY.items()])
+            + extra_custom_types_and_prefixes
+        )
     )
-    _validate_prefixes(custom_types_and_prefixes)
+    _, prefixes = zip(*custom_types_and_prefixes)
+    _validate_prefixes(prefixes)
     pytree_with_serialized_arrays = json.loads(serialized)
     return tree_util.tree_map(
         functools.partial(
@@ -109,7 +204,7 @@ def _maybe_deserialize(
     if not isinstance(maybe_serialized, str):
         return maybe_serialized
 
-    if maybe_serialized.startswith(PREFIX_NUMPY):
+    if maybe_serialized.startswith(_PREFIX_NUMPY):
         return _deserialize_array(maybe_serialized)
     for custom_type, prefix in custom_types_and_prefixes:
         if maybe_serialized.startswith(prefix):
@@ -122,18 +217,6 @@ def _maybe_deserialize(
 def _deserialize_array(serialized_array: Any) -> Any:
     """Deserializes a numpy array from a string."""
     memfile = io.BytesIO()
-    memfile.write(serialized_array.encode(NUMPY_ASCII_FORMAT))
+    memfile.write(serialized_array.encode(_NUMPY_ASCII_FORMAT))
     memfile.seek(0)
     return onp.load(memfile)
-
-
-def _validate_prefixes(
-    custom_types_and_prefixes: Tuple[Tuple[Any, str], ...],
-) -> None:
-    """Validates that prefixes are compatible."""
-    prefixes = [prefix for _, prefix in custom_types_and_prefixes]
-    prefixes.append(PREFIX_NUMPY)
-
-    for i, test_prefix in enumerate(prefixes):
-        if any(p.startswith(test_prefix) for p in prefixes[i + 1 :]):
-            raise ValueError(f"Found conflicting prefixes, got {prefixes}")

--- a/src/totypes/types.py
+++ b/src/totypes/types.py
@@ -11,7 +11,7 @@ import jax.numpy as jnp
 import numpy as onp
 from jax import tree_util
 
-from totypes import symmetry
+from totypes import json_utils, symmetry
 
 Array = Union[jnp.ndarray, onp.ndarray]
 ArrayOrScalar = Union[Array, float, int]
@@ -115,6 +115,8 @@ tree_util.register_pytree_node(
     flatten_func=_flatten_bounded_array,
     unflatten_func=_unflatten_bounded_array,
 )
+
+json_utils.register_custom_type(BoundedArray)
 
 
 # -----------------------------------------------------------------------------
@@ -317,6 +319,9 @@ tree_util.register_pytree_node(
     flatten_func=_flatten_density_2d,
     unflatten_func=_unflatten_density_2d,
 )
+
+
+json_utils.register_custom_type(Density2DArray)
 
 
 def symmetrize_density(density: Density2DArray) -> Density2DArray:

--- a/tests/test_json_utils_server_client.py
+++ b/tests/test_json_utils_server_client.py
@@ -1,0 +1,86 @@
+"""Defines tests for the `totypes.json_utils` module.
+
+Copyright (c) 2023 The INVRS-IO authors.
+"""
+
+import dataclasses
+import functools
+import unittest
+from concurrent import futures
+from typing import NamedTuple
+
+import numpy as onp
+
+
+class CustomObject(NamedTuple):
+    x: onp.ndarray
+    y: int
+    z: str
+
+
+def get_prefixes(register_type):
+    from totypes import json_utils
+
+    if register_type:
+        json_utils.register_custom_type(CustomObject)
+    return tuple(json_utils._CUSTOM_TYPE_REGISTRY.keys())
+
+
+def serialize():
+    from totypes import json_utils
+
+    json_utils.register_custom_type(CustomObject)
+    return json_utils.json_from_pytree(
+        CustomObject(
+            x=onp.ones((1, 1)),
+            y=2,
+            z="test",
+        )
+    )
+
+
+def deserialize(serialized):
+    from totypes import json_utils
+
+    json_utils.register_custom_type(CustomObject)
+    return json_utils.pytree_from_json(serialized)
+
+
+def serialize_deserialize():
+    return deserialize(serialize())
+
+
+class TestServerClient(unittest.TestCase):
+    def test_error_if_client_server_do_not_both_define_object(self):
+        # Test that two separate processes must both register custom types. If the
+        # two functions were to run on a single process, this owuld not be the case.
+        with futures.ProcessPoolExecutor() as executor:
+            running_tasks = [
+                executor.submit(task)
+                for task in [
+                    functools.partial(get_prefixes, register_type=True),
+                    functools.partial(get_prefixes, register_type=False),
+                ]
+            ]
+            server_prefixes, client_prefixes = [task.result() for task in running_tasks]
+
+        self.assertFalse(len(server_prefixes) == len(client_prefixes))
+
+    def test_client_serialize_server_deserialize(self):
+        # Perform serialization and deserialization in two separate processes, each
+        # of which independently imports `json_utils` and registers `CustomObject`.
+        with futures.ProcessPoolExecutor() as executor:
+            serialized = executor.submit(serialize).result()
+            pytree = executor.submit(deserialize, serialized).result()
+        self.assertIsInstance(pytree, CustomObject)
+        onp.testing.assert_array_equal(pytree.x, onp.ones((1, 1)))
+        self.assertEqual(pytree.y, 2)
+        self.assertEqual(pytree.z, "test")
+
+        # As a sanity check, try to perform the same operation on a single process.
+        # This should fail, because it results in duplicate registration.
+        with self.assertRaisesRegex(
+            ValueError, "Duplicate custom type registration for"
+        ):
+            with futures.ProcessPoolExecutor() as executor:
+                executor.submit(serialize_deserialize).result()

--- a/tests/test_json_utils_server_client.py
+++ b/tests/test_json_utils_server_client.py
@@ -3,7 +3,6 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-import dataclasses
 import functools
 import unittest
 from concurrent import futures

--- a/tests/test_json_utils_server_client.py
+++ b/tests/test_json_utils_server_client.py
@@ -61,7 +61,7 @@ class TestServerClient(unittest.TestCase):
                     functools.partial(get_prefixes, register_type=False),
                 ]
             ]
-            server_prefixes, client_prefixes = [task.result() for task in running_tasks]
+            server_prefixes, client_prefixes = (task.result() for task in running_tasks)
 
         self.assertFalse(len(server_prefixes) == len(client_prefixes))
 


### PR DESCRIPTION
Registering custom types allows one to avoid providing additional type-specific information at the callsite for serialization/deserialization.