### PR TITLE
Make type registry deterministic

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.3.0"
+current_version = "v0.4.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # totypes - Custom types for topology optimization
-`v0.3.0`
+`v0.4.0`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "totypes"
-version = "v0.3.0"
+version = "v0.4.0"
 description = "Custom datatypes useful in a topology optimization context"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/totypes/__init__.py
+++ b/src/totypes/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.3.0"
+__version__ = "v0.4.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 __all__ = ["json_utils", "symmetry", "types"]

--- a/src/totypes/json_utils.py
+++ b/src/totypes/json_utils.py
@@ -30,6 +30,8 @@ def register_custom_type(custom_type: Any) -> None:
     Args:
         custom_type: The custom type to be serialized.
     """
+    if type(custom_type) is not type:
+        raise ValueError(f"`custom_type` must be a type, but got {type(custom_type)}.")
     if not (dataclasses.is_dataclass(custom_type) or _is_namedtuple(custom_type)):
         raise ValueError(
             f"Only dataclasses and namedtuples are supported, but got {custom_type}."
@@ -43,10 +45,7 @@ def register_custom_type(custom_type: Any) -> None:
 
 def _prefix_for_custom_type(custom_type: Any) -> str:
     """Return the prefix for a custom type."""
-    type_str = str(custom_type)
-    type_hash = hash(type_str)
-    type_hash_str = f"{'p' if type_hash > 0 else 'n'}{abs(type_hash)}"
-    return f"\x93TYPES.{type_hash_str}.{type_str}."
+    return f"\x93TOTYPES.REGISTERED_CUSTOM_TYPE.{str(custom_type)}"
 
 
 def _validate_prefix(test_prefix: str, existing_prefixes: Sequence[str]) -> None:

--- a/tests/test_json_utils.py
+++ b/tests/test_json_utils.py
@@ -247,3 +247,40 @@ class TestAllCustomTypesHaveAPrefix(unittest.TestCase):
         custom_types = json_utils._CUSTOM_TYPE_REGISTRY.values()
         for t in types.CUSTOM_TYPES:
             self.assertTrue(t in custom_types)
+
+
+class RegisterCustomTypeValidation(unittest.TestCase):
+    def test_is_not_dataclass_or_namedtuple(self):
+        class MyClass123:
+            pass
+
+        with self.assertRaisesRegex(
+            ValueError, "Only dataclasses and namedtuples are supported"
+        ):
+            json_utils.register_custom_type(MyClass123)
+
+    def test_is_not_type(self):
+        @dataclasses.dataclass
+        class MyClass123:
+            pass
+
+        json_utils.register_custom_type(MyClass123)
+        self.assertTrue(
+            any(
+                ["MyClass123" in key for key in json_utils._CUSTOM_TYPE_REGISTRY.keys()]
+            )
+        )
+        print(type(MyClass123()))
+        with self.assertRaisesRegex(
+            ValueError, "`custom_type` must be a type, but got"
+        ):
+            json_utils.register_custom_type(MyClass123())
+
+    def test_duplicate_registration(self):
+        @dataclasses.dataclass
+        class MyClass123:
+            pass
+
+        json_utils.register_custom_type(MyClass123)
+        with self.assertRaisesRegex(ValueError, "Duplicate custom type registration"):
+            json_utils.register_custom_type(MyClass123)


### PR DESCRIPTION
The previous type registry made use of `hash`, which we have since learned is non-deterministic. This makes it impossible to save and restore custom types across different python instances/processes. Here, we make things deterministic.