### PR TITLE
Allow broadcasting of fixed pixels

### DIFF
--- a/.bumpversion.toml
+++ b/.bumpversion.toml
@@ -1,5 +1,5 @@
 [tool.bumpversion]
-current_version = "v0.5.0"
+current_version = "v0.6.0"
 commit = true
 commit_args = "--no-verify"
 tag = true

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # totypes - Custom types for topology optimization
-`v0.5.0`
+`v0.6.0`
 
 ## Overview
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 
 name = "totypes"
-version = "v0.5.0"
+version = "v0.6.0"
 description = "Custom datatypes useful in a topology optimization context"
 keywords = ["topology", "optimization", "jax", "inverse design"]
 readme = "README.md"

--- a/src/totypes/__init__.py
+++ b/src/totypes/__init__.py
@@ -3,7 +3,7 @@
 Copyright (c) 2023 The INVRS-IO authors.
 """
 
-__version__ = "v0.5.0"
+__version__ = "v0.6.0"
 __author__ = "Martin F. Schubert <mfschubert@gmail.com>"
 
 __all__ = ["json_utils", "symmetry", "types"]

--- a/src/totypes/types.py
+++ b/src/totypes/types.py
@@ -182,12 +182,22 @@ class Density2DArray:
                 f"{self.lower_bound} and {self.upper_bound}"
             )
 
-        if self.fixed_solid is not None and self.fixed_solid.shape != self.array.shape:
+        if self.fixed_solid is not None and (
+            jnp.ndim(self.fixed_solid) > jnp.ndim(self.array)
+            or self.fixed_solid.shape[-2:] != self.array.shape[-2:]
+            or not _shapes_compatible(
+                jnp.shape(self.array), jnp.shape(self.fixed_solid)
+            )
+        ):
             raise ValueError(
                 f"`fixed_solid` must have shape matching `array`, but got shape "
                 f"{self.fixed_solid.shape} when `array` has shape {self.array.shape}."
             )
-        if self.fixed_void is not None and self.fixed_void.shape != self.array.shape:
+        if self.fixed_void is not None and (
+            jnp.ndim(self.fixed_void) > jnp.ndim(self.array)
+            or self.fixed_void.shape[-2:] != self.array.shape[-2:]
+            or not _shapes_compatible(jnp.shape(self.array), jnp.shape(self.fixed_void))
+        ):
             raise ValueError(
                 f"`fixed_void` must have shape matching `array`, but got shape "
                 f"{self.fixed_void.shape} when `array` has shape {self.array.shape}."

--- a/tests/test_partition_utils.py
+++ b/tests/test_partition_utils.py
@@ -7,8 +7,8 @@ import itertools
 import unittest
 
 import jax
-from jax import tree_util
 import numpy as onp
+from jax import tree_util
 from parameterized import parameterized
 
 from totypes import partition_utils, types


### PR DESCRIPTION
This PR loosens the validation on density objects, so that e.g. jacobians may be computed.